### PR TITLE
Early module implementation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,9 +2,11 @@
     "sourceMaps": true,
     "presets": [
         "@babel/preset-env",
+        "@babel/preset-react",
         "@babel/preset-typescript"
     ],
     "plugins": [
-        "@babel/plugin-proposal-class-properties"
+        "@babel/plugin-proposal-class-properties",
+        "@babel/plugin-transform-runtime"
     ]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     overrides: [{
         files: [
             "**/*.ts",
+            "**/*.tsx",
         ],
         extends: [
             "plugin:matrix-org/typescript",

--- a/README.md
+++ b/README.md
@@ -1,11 +1,29 @@
 # element-web-ilag-module
-Proof of concept for https://github.com/matrix-org/matrix-react-sdk-module-api
+A simple Improved Landing As Guest (ILAG) module to demonstrate some functionality of Element Web's Module API.
 
-## TODO
+To install, visit https://github.com/vector-im/element-web/blob/develop/docs/modules.md and install the module
+according to the examples.
 
-* [ ] Write a better intro/readme
-* [ ] Proof of concept
-* [ ] If approved, make it a real npm package (should we?)
-* [ ] If approved, fix access controls
-* [ ] If approved, maintain this
-* [ ] Move to matrix-org?
+As part of your `config.json` for element-web, add the following section:
+
+```json
+{
+  "io.element.module.ilag": {
+    "localpartTemplate": "{firstName}{lastName}",
+    "passwordTemplate": "{randomString}"
+  }
+}
+```
+
+For both templates, the following variables are supported:
+
+* `{{randomString}}` - A random string of arbitrary length and complexity, lowercase.
+* `{{firstName}}` - The first name the user supplied, lowercase.
+* `{{lastName}}` - The last name the user supplied, lowercase.
+
+For localparts, non-alphanumeric characters will be removed.
+
+The templates shown above are treated as the defaults, if not provided.
+
+To trigger the module once installed, visit a room where you have peek access and while not logged in. The app
+should prompt you to try and "join" the chat - click that and follow the prompts.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "rimraf lib",
     "build": "yarn clean && yarn build:compile && yarn build:types",
     "build:types": "tsc -p ./tsconfig.build.json --emitDeclarationOnly",
-    "build:compile": "babel -d lib --verbose --extensions \".ts\" src",
+    "build:compile": "babel -d lib --verbose --extensions \".ts,.tsx\" src",
     "start": "tsc -p ./tsconfig.build.json -w",
     "test": "jest",
     "lint": "eslint src test && tsc --noEmit",
@@ -30,9 +30,12 @@
     "@babel/eslint-parser": "^7.17.0",
     "@babel/eslint-plugin": "^7.17.7",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
+    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
+    "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@types/jest": "^27.4.1",
+    "@types/react": "^17",
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
     "eslint": "^8.12.0",
@@ -43,5 +46,8 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.3"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.17.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9"
+    "@babel/runtime": "^7.17.9",
+    "@matrix-org/react-sdk-module-api": "^0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@types/jest": "^27.4.1",
     "@types/react": "^17",
+    "@types/string-template": "^1.0.2",
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
     "eslint": "^8.12.0",
@@ -49,6 +50,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "@matrix-org/react-sdk-module-api": "^0.0.3"
+    "@matrix-org/react-sdk-module-api": "^0.0.3",
+    "string-template": "^1.0.0"
   }
 }

--- a/src/IlagModule.ts
+++ b/src/IlagModule.ts
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 New Vector Ltd. t/a Element
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { RuntimeModule } from "@matrix-org/react-sdk-module-api/lib/RuntimeModule";
+import { ModuleApi } from "@matrix-org/react-sdk-module-api/lib/ModuleApi";
+import {
+    JoinFromPreviewListener,
+    RoomPreviewListener,
+    RoomViewLifecycle,
+} from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
+
+export default class IlagModule extends RuntimeModule {
+    public constructor(moduleApi: ModuleApi) {
+        super(moduleApi);
+
+        this.on(RoomViewLifecycle.PreviewRoomNotLoggedIn, this.onRoomPreviewBar);
+        this.on(RoomViewLifecycle.JoinFromRoomPreview, this.onTryJoin);
+    }
+
+    protected onRoomPreviewBar: RoomPreviewListener = (opts, roomId) => {
+        opts.canJoin = true; // don't show login/signup options - use "join now" language
+    };
+
+    protected onTryJoin: JoinFromPreviewListener = (roomId) => {
+        console.log("@@ WE DID A THING");
+    };
+}

--- a/src/IlagModule.tsx
+++ b/src/IlagModule.tsx
@@ -48,11 +48,11 @@ export default class IlagModule extends RuntimeModule {
         this.moduleApi.openDialog<AccountModel, DialogProps, AskNameDialog>(
             this.t("Welcome! Enter your name to join"),
             (props, ref) => <AskNameDialog ref={ref} {...props} />,
-        ).then(async ({ didSubmit, model }) => {
-            if (!didSubmit) return;
+        ).then(async ({ didOkOrSubmit, model }) => {
+            if (!didOkOrSubmit) return;
 
-            await this.moduleApi.useAccount(model.creds);
-            await this.moduleApi.switchToRoom(roomId, true);
+            await this.moduleApi.overwriteAccountAuth(model.creds);
+            await this.moduleApi.navigatePermalink(`https://matrix.to/#/${roomId}`, true);
         });
     };
 }

--- a/src/IlagModule.tsx
+++ b/src/IlagModule.tsx
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import React from "react";
 import { RuntimeModule } from "@matrix-org/react-sdk-module-api/lib/RuntimeModule";
 import { ModuleApi } from "@matrix-org/react-sdk-module-api/lib/ModuleApi";
 import {
@@ -21,9 +22,9 @@ import {
     RoomPreviewListener,
     RoomViewLifecycle,
 } from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
-import { AskNameDialog, AccountModel } from "./components/AskNameDialog";
-import React from "react";
 import { DialogProps } from "@matrix-org/react-sdk-module-api/lib/components/DialogContent";
+
+import { AskNameDialog, AccountModel } from "./components/AskNameDialog";
 
 export default class IlagModule extends RuntimeModule {
     public constructor(moduleApi: ModuleApi) {

--- a/src/components/AskNameDialog.tsx
+++ b/src/components/AskNameDialog.tsx
@@ -19,7 +19,9 @@ import { DialogProps, DialogState } from "@matrix-org/react-sdk-module-api/lib/c
 import { DialogContent } from "@matrix-org/react-sdk-module-api/lib/components/DialogContent";
 import { TextInputField } from "@matrix-org/react-sdk-module-api/lib/components/TextInputField";
 import { Spinner } from "@matrix-org/react-sdk-module-api/lib/components/Spinner";
-import { AccountAuthInfo } from "@matrix-org/react-sdk-module-api/src/types/AccountAuthInfo";
+import { AccountAuthInfo } from "@matrix-org/react-sdk-module-api/lib/types/AccountAuthInfo";
+
+import { fillLocalpart, fillPassword, TemplateVars } from "../templates";
 
 interface Props extends DialogProps {
     // we don't need anything new
@@ -37,10 +39,13 @@ export interface AccountModel {
 export class AskNameDialog extends DialogContent<Props, State, AccountModel> {
     public async trySubmit(): Promise<AccountModel> {
         this.setState({ busy: true });
-        // TODO: @@ Proper ID generation using a config setting
-        const localpart = `${this.state.firstName}_${this.state.lastName}`.toLowerCase().replace(/[^0-9a-z]/g, '');
-        // TODO: @@ Proper password generation/usage
-        const creds = await this.props.moduleApi.registerSimpleAccount(localpart, localpart, `${this.state.firstName} ${this.state.lastName}`);
+        const vars: TemplateVars = {
+            firstName: this.state.firstName,
+            lastName: this.state.lastName,
+        };
+        const localpart = fillLocalpart(this.props.moduleApi, vars);
+        const password = fillPassword(this.props.moduleApi, vars);
+        const creds = await this.props.moduleApi.registerSimpleAccount(localpart, localpart, password);
         return { creds };
     }
 

--- a/src/components/AskNameDialog.tsx
+++ b/src/components/AskNameDialog.tsx
@@ -19,7 +19,7 @@ import { DialogProps, DialogState } from "@matrix-org/react-sdk-module-api/lib/c
 import { DialogContent } from "@matrix-org/react-sdk-module-api/lib/components/DialogContent";
 import { TextInputField } from "@matrix-org/react-sdk-module-api/lib/components/TextInputField";
 import { Spinner } from "@matrix-org/react-sdk-module-api/lib/components/Spinner";
-import { AccountCredentials } from "@matrix-org/react-sdk-module-api/lib/types/credentials";
+import { AccountAuthInfo } from "@matrix-org/react-sdk-module-api/src/types/AccountAuthInfo";
 
 interface Props extends DialogProps {
     // we don't need anything new
@@ -31,7 +31,7 @@ interface State extends DialogState {
 }
 
 export interface AccountModel {
-    creds: AccountCredentials;
+    creds: AccountAuthInfo;
 }
 
 export class AskNameDialog extends DialogContent<Props, State, AccountModel> {
@@ -40,7 +40,7 @@ export class AskNameDialog extends DialogContent<Props, State, AccountModel> {
         // TODO: @@ Proper ID generation using a config setting
         const localpart = `${this.state.firstName}_${this.state.lastName}`.toLowerCase().replace(/[^0-9a-z]/g, '');
         // TODO: @@ Proper password generation/usage
-        const creds = await this.props.moduleApi.registerAccount(localpart, localpart, `${this.state.firstName} ${this.state.lastName}`);
+        const creds = await this.props.moduleApi.registerSimpleAccount(localpart, localpart, `${this.state.firstName} ${this.state.lastName}`);
         return { creds };
     }
 

--- a/src/components/AskNameDialog.tsx
+++ b/src/components/AskNameDialog.tsx
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 New Vector Ltd. t/a Element
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as React from "react";
+import { DialogProps, DialogState } from "@matrix-org/react-sdk-module-api/lib/components/DialogContent";
+import { DialogContent } from "@matrix-org/react-sdk-module-api/lib/components/DialogContent";
+import { TextInputField } from "@matrix-org/react-sdk-module-api/lib/components/TextInputField";
+import { Spinner } from "@matrix-org/react-sdk-module-api/lib/components/Spinner";
+import { AccountCredentials } from "@matrix-org/react-sdk-module-api/lib/types/credentials";
+
+interface Props extends DialogProps {
+    // we don't need anything new
+}
+
+interface State extends DialogState {
+    firstName: string;
+    lastName: string;
+}
+
+export interface AccountModel {
+    creds: AccountCredentials;
+}
+
+export class AskNameDialog extends DialogContent<Props, State, AccountModel> {
+    public async trySubmit(): Promise<AccountModel> {
+        this.setState({ busy: true });
+        // TODO: @@ Proper ID generation using a config setting
+        const localpart = `${this.state.firstName}_${this.state.lastName}`.toLowerCase().replace(/[^0-9a-z]/g, '');
+        // TODO: @@ Proper password generation/usage
+        const creds = await this.props.moduleApi.registerAccount(localpart, localpart, `${this.state.firstName} ${this.state.lastName}`);
+        return { creds };
+    }
+
+    public render() {
+        if (this.state.busy) {
+            return <>
+                <Spinner />
+                <p>{ this.t("Creating your account...") }</p>
+            </>;
+        }
+
+        return <>
+            { this.state.error }
+            <TextInputField
+                label={this.t("First name")}
+                value={this.state.firstName}
+                onChange={(s) => this.setState({ firstName: s })}
+            />
+            <TextInputField
+                label={this.t("Last name")}
+                value={this.state.lastName}
+                onChange={(s) => this.setState({ lastName: s })}
+            />
+        </>;
+    }
+}

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 New Vector Ltd. t/a Element
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import format from "string-template";
+import { ModuleApi } from "@matrix-org/react-sdk-module-api/lib/ModuleApi";
+
+const DEFAULT_LOCALPART_TEMPLATE = "{firstName}_{lastName}";
+const DEFAULT_PASSWORD_TEMPLATE = "{randomString}";
+
+export type TemplateVars = {
+    firstName: string;
+    lastName: string;
+};
+
+export function fillTemplate(templateStr: string, vars: TemplateVars): string {
+    const buf = new Uint8Array(64);
+    crypto.getRandomValues(buf);
+    const newVars = {
+        firstName: vars.firstName.toLowerCase(),
+        lastName: vars.lastName.toLowerCase(),
+        randomString: Buffer.from(buf).toString('hex').toLowerCase(),
+    };
+
+    return format(templateStr, newVars);
+}
+
+export function fillLocalpart(moduleApi: ModuleApi, vars: TemplateVars): string {
+    const str = moduleApi.getConfigValue("io.element.module.ilag", "localpartTemplate")
+        || DEFAULT_LOCALPART_TEMPLATE;
+    if (typeof str !== "string") throw new Error("Runtime error: localpartTemplate is not a string");
+    return fillTemplate(str, vars);
+}
+
+export function fillPassword(moduleApi: ModuleApi, vars: TemplateVars): string {
+    const str = moduleApi.getConfigValue("io.element.module.ilag", "passwordTemplate")
+        || DEFAULT_PASSWORD_TEMPLATE;
+    if (typeof str !== "string") throw new Error("Runtime error: passwordTemplate is not a string");
+    return fillTemplate(str, vars);
+}

--- a/test/placeholder.test.ts
+++ b/test/placeholder.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// We don't have anything which needs tests at the moment, so stub out a test
+// to appease the linter's requirements.
+
+describe("placeholder", () => {
+    it('should pass the linter', () => {
+        // nothing to do.
+    });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,9 +7,11 @@
     "module": "commonjs",
     "emitDecoratorMetadata": true,
     "declaration": true,
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "jsx": "react"
   },
   "include": [
-    "./src/**/*.ts"
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,12 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "declaration": false,
-    "noEmit": true
+    "noEmit": true,
+    "jsx": "react"
   },
   "include": [
     "./src/**/*.ts",
+    "./src/**/*.tsx",
     "./test/**/*.ts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,6 +505,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/plugin-syntax-jsx@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665"
+  integrity sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4", "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
@@ -753,6 +760,39 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
+"@babel/plugin-transform-react-display-name@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz#7b6d40d232f4c0f550ea348593db3b21e2404340"
+  integrity sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
+"@babel/plugin-transform-react-jsx-development@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz#43a00724a3ed2557ed3f276a01a929e6686ac7b8"
+  integrity sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==
+  dependencies:
+    "@babel/plugin-transform-react-jsx" "^7.16.7"
+
+"@babel/plugin-transform-react-jsx@^7.16.7":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz#eac1565da176ccb1a715dae0b4609858808008c1"
+  integrity sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-jsx" "^7.16.7"
+    "@babel/types" "^7.17.0"
+
+"@babel/plugin-transform-react-pure-annotations@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.7.tgz#232bfd2f12eb551d6d7d01d13fe3f86b45eb9c67"
+  integrity sha512-hs71ToC97k3QWxswh2ElzMFABXHvGiJ01IB1TbYQDGeWRKWz/MPUTh5jGExdHvosYKpnJW5Pm3S4+TA3FyX+GA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-regenerator@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz#9e7576dc476cb89ccc5096fff7af659243b4adeb"
@@ -766,6 +806,18 @@
   integrity sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
+
+"@babel/plugin-transform-runtime@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz#0a2e08b5e2b2d95c4b1d3b3371a2180617455b70"
+  integrity sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    babel-plugin-polyfill-corejs2 "^0.3.0"
+    babel-plugin-polyfill-corejs3 "^0.5.0"
+    babel-plugin-polyfill-regenerator "^0.3.0"
+    semver "^6.3.0"
 
 "@babel/plugin-transform-shorthand-properties@^7.16.7":
   version "7.16.7"
@@ -918,6 +970,18 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
+"@babel/preset-react@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.16.7.tgz#4c18150491edc69c183ff818f9f2aecbe5d93852"
+  integrity sha512-fWpyI8UM/HE6DfPBzD8LnhQ/OcH8AgTaqcqP2nGOXEUV+VKBR5JRN9hCk9ai+zQQ57vtm9oWeXguBCPNUjytgA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-validator-option" "^7.16.7"
+    "@babel/plugin-transform-react-display-name" "^7.16.7"
+    "@babel/plugin-transform-react-jsx" "^7.16.7"
+    "@babel/plugin-transform-react-jsx-development" "^7.16.7"
+    "@babel/plugin-transform-react-pure-annotations" "^7.16.7"
+
 "@babel/preset-typescript@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz#ab114d68bb2020afc069cd51b37ff98a046a70b9"
@@ -926,6 +990,13 @@
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.16.7"
+
+"@babel/runtime@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.8.4":
   version "7.17.8"
@@ -1335,6 +1406,25 @@
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"
   integrity sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
+
+"@types/prop-types@*":
+  version "15.7.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
+  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
+"@types/react@^17":
+  version "17.0.43"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
+  integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -1891,6 +1981,11 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^3.0.2:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
+  integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
 
 data-urls@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,6 +1275,13 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@matrix-org/react-sdk-module-api@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@matrix-org/react-sdk-module-api/-/react-sdk-module-api-0.0.3.tgz#a7ac1b18a72d18d08290b81fa33b0d8d00a77d2b"
+  integrity sha512-jQmLhVIanuX0g7Jx1OIqlzs0kp72PfSpv3umi55qVPYcAPQmO252AUs0vncatK8O4e013vohdnNhly19a/kmLQ==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz#323d72dd25103d0c4fbdce89dadf574a787b1f9b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,6 +1438,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/string-template@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/string-template/-/string-template-1.0.2.tgz#363b273c9b456705e3111e3571e9248f6474eba4"
+  integrity sha512-7VFuFekVzbr0uktqfBmsJc/CqjwnXWWOc5mHn7rajxzhLO9aM9nMMhtpa+90UK1GW6C0ctQF/9Fh0qJBwjqNXg==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -4051,6 +4056,11 @@ string-length@^4.0.1:
   dependencies:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
+
+string-template@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string-template/-/string-template-1.0.0.tgz#9e9f2233dc00f218718ec379a28a5673ecca8b96"
+  integrity sha512-SLqR3GBUXuoPP5MmYtD7ompvXiG87QjT6lzOszyXjTM86Uu7At7vNnt2xgyTLq5o9T4IxTYFyGxcULqpsmsfdg==
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"


### PR DESCRIPTION
This contains the bare minimum to demonstrate how a module API might work. Other modules may be more complex, but would see a similar setup.

At the moment, this is not formally tested. Testing these sorts of things is complicated and best suited for a future PR due to shear size.

The intent is that the module has the tests to make sure it works within an Element Web, using some sort of Cypress-like setup.

----

Part of a series:
* https://github.com/matrix-org/matrix-react-sdk/pull/8246
* https://github.com/vector-im/element-web/pull/21703
* https://github.com/matrix-org/matrix-react-sdk-module-api/pull/1
