### PR TITLE
Fix issue where registerSimpleAccount would be called with parameters in the wrong order

### DIFF
--- a/src/components/AskNameDialog.tsx
+++ b/src/components/AskNameDialog.tsx
@@ -45,7 +45,7 @@ export class AskNameDialog extends DialogContent<Props, State, AccountModel> {
         };
         const localpart = fillLocalpart(this.props.moduleApi, vars);
         const password = fillPassword(this.props.moduleApi, vars);
-        const creds = await this.props.moduleApi.registerSimpleAccount(localpart, localpart, password);
+        const creds = await this.props.moduleApi.registerSimpleAccount(localpart, password, localpart);
         return { creds };
     }
 


### PR DESCRIPTION
Related: [PSC-267](https://element-io.atlassian.net/browse/PSC-267)

`registerSimpleAccount` is defined as

```typescript
    /**
     * Registers for an account on the currently connected homeserver. This requires that the homeserver
     * offer a password-only flow without other flows. This means it is not traditionally compatible with
     * homeservers like matrix.org which also generally require a combination of reCAPTCHA, email address,
     * terms of service acceptance, etc.
     * @param username The username to register.
     * @param password The password to register.
     * @param displayName Optional display name to set.
     * @returns Resolves to the authentication info for the created account.
     */
    registerSimpleAccount(username: string, password: string, displayName?: string): Promise<AccountAuthInfo>;
```

[PSC-267]: https://element-io.atlassian.net/browse/PSC-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ